### PR TITLE
fix: use non ssl in dev mode for cookies

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import { createInstance } from '$lib/pocketbase';
 import type { Handle } from '@sveltejs/kit';
+import { dev } from '$app/environment';
 
 export const handle: Handle = async ({ event, resolve }) => {
 	const pb = createInstance();
@@ -22,9 +23,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
 
 	// send back the default 'pb_auth' cookie to the client with the latest store state
+	// secure: !dev disables ssl requirement in dev mode and enables it in prod mode
 	response.headers.set(
 		'set-cookie',
-		pb.authStore.exportToCookie({ httpOnly: false, sameSite: 'lax' })
+		pb.authStore.exportToCookie({ httpOnly: false, sameSite: 'lax', secure: !dev })
 	);
 
 	return response;


### PR DESCRIPTION
As mentioned in #12 the app was not allowing to login in dev mode because the cookie was being created in secure (SSL) enabled. This changes disables `https` in the dev mode and enables it back in prod mode.